### PR TITLE
Add InfluxDB

### DIFF
--- a/data/influxdb
+++ b/data/influxdb
@@ -1,0 +1,8 @@
+name:     InfluxDB
+url:      https://www.influxdata.com/get-influxdb/
+db:       InfluxDB
+api:      REST
+lang:     Go
+license:  MIT License
+notes:    A timeseries database with a built-in REST API. \
+          [Official Docker image](https://hub.docker.com/_/influxdb).


### PR DESCRIPTION
Adds [InfluxDB](https://www.influxdata.com/get-influxdb/), a timeseries database with built-in REST API.

InfluxDB has open source application (MIT Licence), an enterprise edition, and a cloud-based PaaS.